### PR TITLE
Refactor V2: code reuse, type safety, and architecture cleanup

### DIFF
--- a/backend/tests/test_toolpath_gen.py
+++ b/backend/tests/test_toolpath_gen.py
@@ -562,7 +562,7 @@ def test_pocket_operation_generates_toolpath():
     """Pocket operation should generate toolpath via pocket_toolpath module."""
     pocket_contour = Contour(
         id="c_pocket",
-        type="pocket",
+        type="exterior",
         coords=[
             [10, 10], [40, 10], [40, 30], [10, 30], [10, 10],
         ],
@@ -684,7 +684,7 @@ def test_pocket_raster_generates_toolpath():
     """Pocket with raster pattern should generate scan-line passes."""
     pocket_contour = Contour(
         id="c_pocket",
-        type="pocket",
+        type="exterior",
         coords=[
             [0, 0], [50, 0], [50, 30], [0, 30], [0, 0],
         ],

--- a/frontend/src/components/PlacementPanel.tsx
+++ b/frontend/src/components/PlacementPanel.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { BrepObject, SheetSettings, PlacementItem } from "../types";
 import { autoNesting } from "../api";
 import SheetTabs from "./SheetTabs";
+import { DEFAULT_SHEET_ID, DEFAULT_CLEARANCE_MM } from "../constants";
 
 /** Rotate a 2D point (x,y) by `angle` degrees around (cx,cy). */
 function rotatePoint(
@@ -58,13 +59,13 @@ export default function PlacementPanel({
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [dragging, setDragging] = useState<string | null>(null);
   const [dragStart, setDragStart] = useState<{ mx: number; my: number; ox: number; oy: number } | null>(null);
-  const [clearance, setClearance] = useState(5);
+  const [clearance, setClearance] = useState(DEFAULT_CLEARANCE_MM);
   const [nestingLoading, setNestingLoading] = useState(false);
 
   // Sheet list derived from placements
   const sheetIds = useMemo(() => {
     const ids = [...new Set(placements.map((p) => p.sheet_id))];
-    if (ids.length === 0) ids.push("sheet_1");
+    if (ids.length === 0) ids.push(DEFAULT_SHEET_ID);
     return ids.sort();
   }, [placements]);
 

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -1,0 +1,1 @@
+export const API_BASE_URL = import.meta.env.VITE_API_URL ?? "http://localhost:8000";

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -1,0 +1,11 @@
+/** Default tool diameter — 1/4" endmill in mm */
+export const DEFAULT_TOOL_DIAMETER_MM = 6.35;
+
+/** Default offset side for contour operations */
+export const DEFAULT_OFFSET_SIDE = "outside" as const;
+
+/** Default sheet ID for initial placement */
+export const DEFAULT_SHEET_ID = "sheet_1";
+
+/** Default clearance for auto nesting (mm) */
+export const DEFAULT_CLEARANCE_MM = 5.0;

--- a/frontend/src/contexts/PanelTabsContext.tsx
+++ b/frontend/src/contexts/PanelTabsContext.tsx
@@ -1,0 +1,16 @@
+import { createContext, useContext } from "react";
+import type { PanelTab } from "../components/SidePanel";
+
+export interface PanelTabsContextValue {
+  openTab: (tab: PanelTab) => void;
+  updateTab: (tab: PanelTab) => void;
+  closeTab: (tabId: string) => void;
+}
+
+export const PanelTabsContext = createContext<PanelTabsContextValue | null>(null);
+
+export function usePanelTabs(): PanelTabsContextValue {
+  const ctx = useContext(PanelTabsContext);
+  if (!ctx) throw new Error("usePanelTabs must be used within PanelTabsContext.Provider");
+  return ctx;
+}

--- a/frontend/src/nodes/BrepImportNode.tsx
+++ b/frontend/src/nodes/BrepImportNode.tsx
@@ -4,13 +4,13 @@ import LabeledHandle from "./LabeledHandle";
 import NodeShell from "../components/NodeShell";
 import { uploadStepFile, fetchMeshData } from "../api";
 import type { BrepImportResult, BrepObject, ObjectMesh } from "../types";
-import type { PanelTab } from "../components/SidePanel";
 import BrepImportPanel from "../components/BrepImportPanel";
+import { usePanelTabs } from "../contexts/PanelTabsContext";
 
 type Status = "idle" | "loading" | "success" | "error";
 
-export default function BrepImportNode({ id, data, selected }: NodeProps) {
-  const openTab = (data as Record<string, unknown>).openTab as ((tab: PanelTab) => void) | undefined;
+export default function BrepImportNode({ id, selected }: NodeProps) {
+  const { openTab } = usePanelTabs();
   const [status, setStatus] = useState<Status>("idle");
   const [result, setResult] = useState<BrepImportResult | null>(null);
   const [error, setError] = useState<string>("");
@@ -76,7 +76,7 @@ export default function BrepImportNode({ id, data, selected }: NodeProps) {
   );
 
   const handleView3D = useCallback(() => {
-    if (!result || !openTab) return;
+    if (!result) return;
     openTab({
       id: `brep-3d-${id}`,
       label: "3D View",

--- a/frontend/src/nodes/CncCodeNode.tsx
+++ b/frontend/src/nodes/CncCodeNode.tsx
@@ -9,10 +9,10 @@ import type {
   PlacementItem,
   BoundingBox,
 } from "../types";
-import type { PanelTab } from "../components/SidePanel";
 import LabeledHandle from "./LabeledHandle";
 import NodeShell from "../components/NodeShell";
 import CncCodePanel from "../components/CncCodePanel";
+import { usePanelTabs } from "../contexts/PanelTabsContext";
 import { useUpstreamData } from "../hooks/useUpstreamData";
 import { generateSbpZip } from "../api";
 import { SheetBadge } from "../components/SheetBadge";
@@ -27,8 +27,8 @@ interface UpstreamZipData {
   postProcessorSettings: PostProcessorSettings;
 }
 
-export default function CncCodeNode({ id, data, selected }: NodeProps) {
-  const openTab = (data as Record<string, unknown>).openTab as ((tab: PanelTab) => void) | undefined;
+export default function CncCodeNode({ id, selected }: NodeProps) {
+  const { openTab } = usePanelTabs();
   const [zipLoading, setZipLoading] = useState(false);
 
   // Subscribe to upstream ToolpathGenNode's outputResult
@@ -115,7 +115,7 @@ export default function CncCodeNode({ id, data, selected }: NodeProps) {
   }, [zipData]);
 
   const handleViewCode = useCallback(() => {
-    if (!outputResult || !openTab) return;
+    if (!outputResult) return;
     openTab({
       id: `cnc-code-${id}`,
       label: "CNC Code",

--- a/frontend/src/nodes/PlacementNode.tsx
+++ b/frontend/src/nodes/PlacementNode.tsx
@@ -8,13 +8,12 @@ import type {
 import { validatePlacement } from "../api";
 import LabeledHandle from "./LabeledHandle";
 import NodeShell from "../components/NodeShell";
-import type { PanelTab } from "../components/SidePanel";
 import PlacementPanel from "../components/PlacementPanel";
+import { usePanelTabs } from "../contexts/PanelTabsContext";
 import { useUpstreamData } from "../hooks/useUpstreamData";
 
-export default function PlacementNode({ id, data, selected }: NodeProps) {
-  const openTab = (data as Record<string, unknown>).openTab as ((tab: PanelTab) => void) | undefined;
-  const updateTab = (data as Record<string, unknown>).updateTab as ((tab: PanelTab) => void) | undefined;
+export default function PlacementNode({ id, selected }: NodeProps) {
+  const { openTab, updateTab } = usePanelTabs();
   const [placements, setPlacements] = useState<PlacementItem[]>([]);
   const [warnings, setWarnings] = useState<string[]>([]);
   const [activeSheetId, setActiveSheetId] = useState("sheet_1");
@@ -212,7 +211,7 @@ export default function PlacementNode({ id, data, selected }: NodeProps) {
   const hasData = brepResult && sheetSettings;
 
   const handleOpenPanel = useCallback(() => {
-    if (!hasData || !openTab) return;
+    if (!hasData) return;
     openTab({
       id: `placement-${id}`,
       label: "Placement",
@@ -233,7 +232,7 @@ export default function PlacementNode({ id, data, selected }: NodeProps) {
 
   // Update tab content when placements/warnings change (only if tab is already open)
   useEffect(() => {
-    if (hasData && updateTab) {
+    if (hasData) {
       updateTab({
         id: `placement-${id}`,
         label: "Placement",

--- a/frontend/src/nodes/PostProcessorNode.tsx
+++ b/frontend/src/nodes/PostProcessorNode.tsx
@@ -1,10 +1,10 @@
 import { useCallback, useEffect, useState } from "react";
 import { Position, type NodeProps, useReactFlow } from "@xyflow/react";
 import type { PostProcessorSettings } from "../types";
-import type { PanelTab } from "../components/SidePanel";
 import LabeledHandle from "./LabeledHandle";
 import NodeShell from "../components/NodeShell";
 import PostProcessorPanel from "../components/PostProcessorPanel";
+import { usePanelTabs } from "../contexts/PanelTabsContext";
 
 const DEFAULT_SETTINGS: PostProcessorSettings = {
   machine_name: "ShopBot PRS-alpha 96-48",
@@ -17,10 +17,10 @@ const DEFAULT_SETTINGS: PostProcessorSettings = {
   warmup_pause: 2,
 };
 
-export default function PostProcessorNode({ id, data, selected }: NodeProps) {
+export default function PostProcessorNode({ id, selected }: NodeProps) {
   const { setNodes } = useReactFlow();
   const [settings, setSettings] = useState<PostProcessorSettings>(DEFAULT_SETTINGS);
-  const openTab = (data as Record<string, unknown>).openTab as ((tab: PanelTab) => void) | undefined;
+  const { openTab } = usePanelTabs();
 
   // Sync settings to node data
   useEffect(() => {
@@ -32,7 +32,6 @@ export default function PostProcessorNode({ id, data, selected }: NodeProps) {
   }, [id, settings, setNodes]);
 
   const handleOpenPanel = useCallback(() => {
-    if (!openTab) return;
     openTab({
       id: `postproc-${id}`,
       label: "Post Proc",

--- a/frontend/src/nodes/ToolpathGenNode.tsx
+++ b/frontend/src/nodes/ToolpathGenNode.tsx
@@ -13,6 +13,7 @@ import LabeledHandle from "./LabeledHandle";
 import NodeShell from "../components/NodeShell";
 import { useUpstreamData } from "../hooks/useUpstreamData";
 import { SheetBadge } from "../components/SheetBadge";
+import { DEFAULT_SHEET_ID } from "../constants";
 
 type Status = "idle" | "loading" | "success" | "error" | "blocked";
 
@@ -43,18 +44,18 @@ export default function ToolpathGenNode({ id, selected }: NodeProps) {
     const objectOrigins = d.objectOrigins as Record<string, [number, number]> | undefined;
     const boundingBoxes = d.boundingBoxes as Record<string, { x: number; y: number; z: number }> | undefined;
     const outlines = d.outlines as Record<string, [number, number][]> | undefined;
-    const upstreamActiveSheetId = (d.activeSheetId as string) || "sheet_1";
+    const upstreamActiveSheetId = (d.activeSheetId as string) || DEFAULT_SHEET_ID;
     if (!detectedOperations || !assignments?.length || !sheetSettings || !placements) return undefined;
     return { detectedOperations, assignments, sheetSettings, placements, objectOrigins: objectOrigins ?? {}, boundingBoxes: boundingBoxes ?? {}, outlines: outlines ?? {}, upstreamActiveSheetId };
   }, []);
   const operations = useUpstreamData(id, `${id}-operations`, extractOperations);
 
-  const activeSheetId = operations?.upstreamActiveSheetId ?? "sheet_1";
+  const activeSheetId = operations?.upstreamActiveSheetId ?? DEFAULT_SHEET_ID;
 
   const allPlacements = operations?.placements ?? [];
   const sheetIds = useMemo(() => {
     const ids = [...new Set(allPlacements.map((p) => p.sheet_id))];
-    if (ids.length === 0) ids.push("sheet_1");
+    if (ids.length === 0) ids.push(DEFAULT_SHEET_ID);
     return ids.sort();
   }, [allPlacements]);
 

--- a/frontend/src/nodes/ToolpathPreviewNode.tsx
+++ b/frontend/src/nodes/ToolpathPreviewNode.tsx
@@ -3,14 +3,14 @@ import { Position, type NodeProps } from "@xyflow/react";
 import type { ToolpathGenResult, SheetSettings, PlacementItem } from "../types";
 import LabeledHandle from "./LabeledHandle";
 import NodeShell from "../components/NodeShell";
-import type { PanelTab } from "../components/SidePanel";
 import ToolpathPreviewPanel from "../components/ToolpathPreviewPanel";
+import { usePanelTabs } from "../contexts/PanelTabsContext";
 import { useUpstreamData } from "../hooks/useUpstreamData";
 import { SheetBadge } from "../components/SheetBadge";
 
-export default function ToolpathPreviewNode({ id, data, selected }: NodeProps) {
+export default function ToolpathPreviewNode({ id, selected }: NodeProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const openTab = (data as Record<string, unknown>).openTab as ((tab: PanelTab) => void) | undefined;
+  const { openTab } = usePanelTabs();
 
   // Subscribe to upstream ToolpathGenNode data
   const extractUpstream = useCallback((d: Record<string, unknown>) => ({
@@ -134,7 +134,7 @@ export default function ToolpathPreviewNode({ id, data, selected }: NodeProps) {
   }, [toolpathResult, drawToolpath]);
 
   const handleEnlarge = useCallback(() => {
-    if (!toolpathResult || !openTab) return;
+    if (!toolpathResult) return;
     openTab({
       id: `preview-${id}`,
       label: "Preview",

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -8,7 +8,7 @@ export interface BoundingBox {
 
 export interface Origin {
   position: [number, number, number];
-  reference: string;
+  reference: "bounding_box_min" | "bounding_box_center" | "model_origin";
   description: string;
 }
 
@@ -24,10 +24,10 @@ export interface BrepObject {
   bounding_box: BoundingBox;
   thickness: number;
   origin: Origin;
-  unit: string;
+  unit: "mm" | "inch";
   is_closed: boolean;
   is_planar: boolean;
-  machining_type: string;
+  machining_type: "2d" | "2.5d" | "double_sided" | "3d";
   faces_analysis: FacesAnalysis;
   outline: [number, number][];  // bottom-face outline, relative to BB min
 }
@@ -42,19 +42,20 @@ export interface BrepImportResult {
 
 export interface Contour {
   id: string;
-  type: string; // "exterior" | "interior"
+  type: "exterior" | "interior" | "pocket" | "drill_center";
   coords: [number, number][];
   closed: boolean;
 }
 
 export interface OffsetApplied {
   distance: number;
-  side: string;
+  side: "outside" | "inside" | "none";
 }
 
 export interface ContourExtractResult {
   object_id: string;
   slice_z: number;
+  thickness: number;
   contours: Contour[];
   offset_applied: OffsetApplied;
 }
@@ -79,7 +80,7 @@ export interface SheetSettings {
 
 export interface Tool {
   diameter: number;
-  type: string; // "endmill" | "ballnose" | "v_bit"
+  type: "endmill" | "ballnose" | "v_bit";
   flutes: number;
 }
 
@@ -96,15 +97,15 @@ export interface TabSettings {
 }
 
 export interface MachiningSettings {
-  operation_type: string; // "contour" | "pocket" | "drill" | "engrave"
+  operation_type: "contour" | "pocket" | "drill" | "engrave";
   tool: Tool;
   feed_rate: FeedRate;
   jog_speed: number;
   spindle_speed: number;
   depth_per_pass: number;
   total_depth: number;
-  direction: string; // "climb" | "conventional"
-  offset_side: string; // "outside" | "inside" | "none"
+  direction: "climb" | "conventional";
+  offset_side: "outside" | "inside" | "none";
   tabs: TabSettings;
   // Pocket-specific
   pocket_pattern?: "contour-parallel" | "raster";
@@ -137,7 +138,7 @@ export interface OperationGeometry {
 export interface DetectedOperation {
   operation_id: string;
   object_id: string;
-  operation_type: string;
+  operation_type: "contour" | "pocket" | "drill" | "engrave";
   geometry: OperationGeometry;
   suggested_settings: MachiningSettings;
   enabled: boolean;
@@ -174,8 +175,8 @@ export interface OperationEditResult {
 
 export interface PostProcessorSettings {
   machine_name: string;
-  output_format: string;
-  unit: string;
+  output_format: "sbp" | "gcode";
+  unit: "mm" | "inch";
   bed_size: [number, number];
   safe_z: number;
   home_position: [number, number];
@@ -213,7 +214,7 @@ export interface ToolpathGenResult {
 export interface OutputResult {
   code: string;
   filename: string;
-  format: string;
+  format: "sbp" | "gcode";
 }
 
 /** Placement types */


### PR DESCRIPTION
## Summary

V2機能実装完了後のコード品質改善リファクタリング。2つのレビュードキュメントをもとに、優先度の高い6項目を実施。

- **api.ts 共通化**: `requestJson`/`requestBlob` ヘルパー導入で11関数の重複fetch/errorパターンを解消
- **バックエンド衛生改善**: `_get_uploaded_step_path()` ヘルパー抽出(4箇所重複解消)、`_generate_sbp_code()` 共通関数化(単体/ZIP重複解消)、`DetectOperationsRequest` を `schemas.py` に移動
- **型安全性強化**: FE/BE 両方で string → Literal/union 型に(operation_type, offset_side, direction 等16箇所)。`ContourExtractResult.thickness` と `OperationAssignment.group_id` のFE/BE不一致を解消
- **node.data runtime分離**: `openTab`/`updateTab`/`closeTab` を `PanelTabsContext` に移行し、node.data を純粋JSONに(将来の保存/復元の前提条件)
- **定数集約**: `config.ts`(API_BASE_URL)と `constants.ts`(DEFAULT_TOOL_DIAMETER_MM等)を新設し、散在するマジック値を一元管理

Closes #29

## Test plan
- [x] `tsc --noEmit` パス
- [x] `vite build` 成功
- [x] Backend pytest: 114 passed, 0 failed
- [x] 既存UI操作で挙動変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)