### PR TITLE
Fix refine quality: add API reference and self-review

### DIFF
--- a/backend/llm_client.py
+++ b/backend/llm_client.py
@@ -35,7 +35,7 @@ AVAILABLE_MODELS: dict[str, dict] = {
     "qwen/qwen3-coder-next": {
         "name": "Qwen3 Coder Next",
         "supports_vision": False,
-        "large_context": False,
+        "large_context": True,
     },
 }
 
@@ -361,7 +361,8 @@ class LLMClient:
         Returns modified Python code string.
         """
         coder_model = PIPELINE_MODELS["coder"]
-        system = _build_system_prompt(profile, include_reference=False)
+        use_reference = _model_has_large_context(coder_model)
+        system = _build_system_prompt(profile, include_reference=use_reference)
 
         messages = list(history)
         messages.append({
@@ -496,7 +497,8 @@ class LLMClient:
     ) -> str:
         """Stage 2.5: Self-review generated code before execution."""
         coder_model = PIPELINE_MODELS["coder"]
-        system = _build_system_prompt(profile, include_reference=False)
+        use_reference = _model_has_large_context(coder_model)
+        system = _build_system_prompt(profile, include_reference=use_reference)
 
         review_content = (
             "以下のコードをレビューしてください:\n"

--- a/backend/tests/test_api_ai_cad.py
+++ b/backend/tests/test_api_ai_cad.py
@@ -94,6 +94,7 @@ def test_refine_endpoint_with_mock_llm():
     with patch("main._get_llm") as mock_get_llm:
         mock_llm = MagicMock()
         mock_llm.refine_code = AsyncMock(return_value=mock_code)
+        mock_llm._self_review = AsyncMock(return_value=mock_code)
         mock_get_llm.return_value = mock_llm
 
         resp = client.post("/ai-cad/refine", json={
@@ -106,6 +107,7 @@ def test_refine_endpoint_with_mock_llm():
     assert resp.status_code == 200
     text = resp.text
     assert "event: stage" in text
+    assert '"reviewing"' in text  # self-review stage
     assert "event: result" in text or "event: error" in text
 
 

--- a/backend/tests/test_llm_client.py
+++ b/backend/tests/test_llm_client.py
@@ -369,6 +369,7 @@ def test_model_has_large_context_helper():
     """_model_has_large_context returns correct values."""
     from llm_client import _model_has_large_context
     assert _model_has_large_context("google/gemini-2.5-flash-lite") is True
+    assert _model_has_large_context("qwen/qwen3-coder-next") is True
     assert _model_has_large_context("deepseek/deepseek-r1") is False
     assert _model_has_large_context("unknown/model") is False
 
@@ -647,6 +648,78 @@ def test_ai_cad_generate_sse_streams_stages():
         assert "event: stage" in text
         assert '"designing"' in text
         assert "event: result" in text
+
+
+@pytest.mark.asyncio
+async def test_refine_code_includes_reference(tmp_path):
+    """refine_code() includes full API reference in system prompt."""
+    from llm_client import _REFERENCE_CACHE, _REF_PATHS
+    _REFERENCE_CACHE.clear()
+    api_ref = tmp_path / "build123d_api_reference.md"
+    api_ref.write_text("REFINE_API_MARKER")
+    examples = tmp_path / "build123d_examples.md"
+    examples.write_text("REFINE_EXAMPLES_MARKER")
+    original_paths = _REF_PATHS.copy()
+    _REF_PATHS["api_reference"] = str(api_ref)
+    _REF_PATHS["examples"] = str(examples)
+
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = "result = Box(100, 50, 20)"
+
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+    client = LLMClient(api_key="test-key")
+    client._client = mock_client
+
+    try:
+        await client.refine_code(
+            current_code="result = Box(100, 50, 10)",
+            message="高さを20mmに変更",
+            history=[],
+        )
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        system_msg = call_kwargs["messages"][0]["content"]
+        assert "REFINE_API_MARKER" in system_msg
+        assert "REFINE_EXAMPLES_MARKER" in system_msg
+    finally:
+        _REF_PATHS.update(original_paths)
+        _REFERENCE_CACHE.clear()
+
+
+@pytest.mark.asyncio
+async def test_self_review_includes_reference(tmp_path):
+    """_self_review() includes full API reference in system prompt."""
+    from llm_client import _REFERENCE_CACHE, _REF_PATHS
+    _REFERENCE_CACHE.clear()
+    api_ref = tmp_path / "build123d_api_reference.md"
+    api_ref.write_text("REVIEW_API_MARKER")
+    examples = tmp_path / "build123d_examples.md"
+    examples.write_text("REVIEW_EXAMPLES_MARKER")
+    original_paths = _REF_PATHS.copy()
+    _REF_PATHS["api_reference"] = str(api_ref)
+    _REF_PATHS["examples"] = str(examples)
+
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = "result = Box(100, 100, 100)"
+
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+    client = LLMClient(api_key="test-key")
+    client._client = mock_client
+
+    try:
+        await client._self_review("box", "result = Box(100,100,100)")
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        system_msg = call_kwargs["messages"][0]["content"]
+        assert "REVIEW_API_MARKER" in system_msg
+        assert "REVIEW_EXAMPLES_MARKER" in system_msg
+    finally:
+        _REF_PATHS.update(original_paths)
+        _REFERENCE_CACHE.clear()
 
 
 def test_list_profiles_info():


### PR DESCRIPTION
## Summary
- チャットでの修正指示（refine）が頻繁にコード実行エラーを起こしていた問題を修正
- 根本原因: `refine_code()` がチートシートのみ（数KB）でLLMを呼び出し、419KB API Reference + 251KB Examples を含めていなかった
- Qwen3-Coder-Next の `large_context` フラグが誤って `False` に設定されていた（実際は256Kトークン対応）

### 変更内容
- Qwen3-Coder-Next の `large_context: True` に修正
- `refine_code()` にフルAPIリファレンス+実装例を含むシステムプロンプトを追加
- `_self_review()` にも同様のリファレンスを追加
- `/ai-cad/refine` エンドポイントにセルフレビューステージを追加（初回+リトライ）

## Test plan
- [x] `cd backend && uv run pytest tests/ -v` — 192 passed, 2 skipped
- [ ] `make dev` → AI CAD ノードで生成 → Refine → チャットで修正指示 → エラーなく修正反映を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)