### PR TITLE
refactor: remove mesh pin from 3D Milling node, use file_id with auto STL conversion

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -109,6 +109,19 @@ def _get_uploaded_step_path(file_id: str) -> Path:
     return matches[0]
 
 
+def _resolve_stl_for_file_id(file_id: str) -> Path:
+    """Resolve file_id to STL path, auto-converting from STEP if needed."""
+    stl_path = UPLOAD_DIR / f"{file_id}.stl"
+    if stl_path.exists():
+        return stl_path
+    step_path = _get_uploaded_step_path(file_id)
+    from nodes.mesh_export import export_step_to_stl
+    result = export_step_to_stl(step_path, output_dir=UPLOAD_DIR)
+    if result.name != f"{file_id}.stl":
+        result.rename(stl_path)
+    return stl_path
+
+
 @app.get("/health")
 def health():
     return {"status": "ok", "version": "0.1.0"}
@@ -564,8 +577,8 @@ def three_d_roughing_endpoint(req: ThreeDRoughingRequest):
     """Generate waterline roughing toolpaths from a mesh file."""
     from nodes.three_d_milling import generate_waterline_roughing
 
-    if not Path(req.mesh_file_path).exists():
-        raise HTTPException(status_code=400, detail=f"Mesh file not found: {req.mesh_file_path}")
+    stl_path = _resolve_stl_for_file_id(req.file_id)
+    req.mesh_file_path = str(stl_path)
 
     try:
         toolpaths = generate_waterline_roughing(req)
@@ -580,8 +593,8 @@ def three_d_finishing_endpoint(req: ThreeDFinishingRequest):
     """Generate raster finishing toolpaths from a mesh file."""
     from nodes.three_d_milling import generate_raster_finishing
 
-    if not Path(req.mesh_file_path).exists():
-        raise HTTPException(status_code=400, detail=f"Mesh file not found: {req.mesh_file_path}")
+    stl_path = _resolve_stl_for_file_id(req.file_id)
+    req.mesh_file_path = str(stl_path)
 
     try:
         toolpaths = generate_raster_finishing(req)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -211,7 +211,7 @@ class ThreeDRoughingRequest(BaseModel):
     stock_to_leave: float = 0.5
     tool: Tool = Tool(diameter=6.35, type="ballnose", flutes=2)
     feed_rate: FeedRate = FeedRate(xy=50.0, z=20.0)
-    spindle_speed: float = 18000.0
+    spindle_speed: int = 18000
     mesh_file_path: str = ""  # resolved internally by endpoint
 
 
@@ -225,7 +225,7 @@ class ThreeDFinishingRequest(BaseModel):
     scan_angle: float = 0.0       # degrees
     tool: Tool = Tool(diameter=3.175, type="ballnose", flutes=2)
     feed_rate: FeedRate = FeedRate(xy=30.0, z=15.0)
-    spindle_speed: float = 18000.0
+    spindle_speed: int = 18000
     mesh_file_path: str = ""  # resolved internally by endpoint
 
 

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -206,7 +206,7 @@ class ThreeDRoughingSettings(BaseModel):
 
 
 class ThreeDRoughingRequest(BaseModel):
-    file_id: str = ""
+    file_id: str
     z_step: float = 3.0
     stock_to_leave: float = 0.5
     tool: Tool = Tool(diameter=6.35, type="ballnose", flutes=2)
@@ -220,7 +220,7 @@ class ThreeDRoughingResult(BaseModel):
 
 
 class ThreeDFinishingRequest(BaseModel):
-    file_id: str = ""
+    file_id: str
     stepover: float = 0.15        # ratio of tool diameter
     scan_angle: float = 0.0       # degrees
     tool: Tool = Tool(diameter=3.175, type="ballnose", flutes=2)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -206,12 +206,13 @@ class ThreeDRoughingSettings(BaseModel):
 
 
 class ThreeDRoughingRequest(BaseModel):
-    mesh_file_path: str
+    file_id: str = ""
     z_step: float = 3.0
     stock_to_leave: float = 0.5
     tool: Tool = Tool(diameter=6.35, type="ballnose", flutes=2)
-    feed_rate: FeedRate = FeedRate(xy=50, z=20)
-    spindle_speed: int = 18000
+    feed_rate: FeedRate = FeedRate(xy=50.0, z=20.0)
+    spindle_speed: float = 18000.0
+    mesh_file_path: str = ""  # resolved internally by endpoint
 
 
 class ThreeDRoughingResult(BaseModel):
@@ -219,12 +220,13 @@ class ThreeDRoughingResult(BaseModel):
 
 
 class ThreeDFinishingRequest(BaseModel):
-    mesh_file_path: str
+    file_id: str = ""
     stepover: float = 0.15        # ratio of tool diameter
     scan_angle: float = 0.0       # degrees
     tool: Tool = Tool(diameter=3.175, type="ballnose", flutes=2)
-    feed_rate: FeedRate = FeedRate(xy=30, z=15)
-    spindle_speed: int = 18000
+    feed_rate: FeedRate = FeedRate(xy=30.0, z=15.0)
+    spindle_speed: float = 18000.0
+    mesh_file_path: str = ""  # resolved internally by endpoint
 
 
 class ThreeDFinishingResult(BaseModel):

--- a/backend/tests/test_3d_milling.py
+++ b/backend/tests/test_3d_milling.py
@@ -45,13 +45,15 @@ class TestThreeDRoughingSettings:
 
 class TestThreeDRoughingRequest:
     def test_minimal(self):
-        req = ThreeDRoughingRequest(mesh_file_path="/tmp/test.stl")
+        req = ThreeDRoughingRequest(file_id="test123", mesh_file_path="/tmp/test.stl")
+        assert req.file_id == "test123"
         assert req.mesh_file_path == "/tmp/test.stl"
         assert req.z_step == 3.0
         assert req.stock_to_leave == 0.5
 
     def test_custom(self):
         req = ThreeDRoughingRequest(
+            file_id="test456",
             mesh_file_path="/tmp/test.stl",
             z_step=1.5,
             stock_to_leave=0.2,
@@ -95,7 +97,7 @@ class TestWaterlineRoughing:
         from nodes.three_d_milling import generate_waterline_roughing
 
         req = ThreeDRoughingRequest(
-            mesh_file_path=str(freeform_stl),
+            file_id="test", mesh_file_path=str(freeform_stl),
             z_step=5.0,
             stock_to_leave=0.0,
         )
@@ -116,7 +118,7 @@ class TestWaterlineRoughing:
         from nodes.three_d_milling import generate_waterline_roughing
 
         req = ThreeDRoughingRequest(
-            mesh_file_path=str(freeform_stl),
+            file_id="test", mesh_file_path=str(freeform_stl),
             z_step=5.0,
             stock_to_leave=0.0,
         )
@@ -134,12 +136,12 @@ class TestWaterlineRoughing:
         from nodes.three_d_milling import generate_waterline_roughing
 
         req_no_stock = ThreeDRoughingRequest(
-            mesh_file_path=str(freeform_stl),
+            file_id="test", mesh_file_path=str(freeform_stl),
             z_step=5.0,
             stock_to_leave=0.0,
         )
         req_with_stock = ThreeDRoughingRequest(
-            mesh_file_path=str(freeform_stl),
+            file_id="test", mesh_file_path=str(freeform_stl),
             z_step=5.0,
             stock_to_leave=2.0,
         )
@@ -155,7 +157,7 @@ class TestWaterlineRoughing:
         from nodes.three_d_milling import generate_waterline_roughing
 
         req = ThreeDRoughingRequest(
-            mesh_file_path="/tmp/does_not_exist.stl",
+            file_id="test", mesh_file_path="/tmp/does_not_exist.stl",
             z_step=5.0,
             stock_to_leave=0.0,
         )
@@ -168,7 +170,7 @@ class TestWaterlineRoughing:
         from sbp_writer import SbpWriter
 
         req = ThreeDRoughingRequest(
-            mesh_file_path=str(freeform_stl),
+            file_id="test", mesh_file_path=str(freeform_stl),
             z_step=10.0,
             stock_to_leave=0.0,
         )
@@ -212,7 +214,7 @@ class TestWaterlineRoughing:
 
 
 def test_three_d_finishing_settings_defaults():
-    req = ThreeDFinishingRequest(mesh_file_path="/tmp/test.stl")
+    req = ThreeDFinishingRequest(file_id="test", mesh_file_path="/tmp/test.stl")
     assert req.stepover == 0.15
     assert req.scan_angle == 0.0
     assert req.tool.type == "ballnose"
@@ -258,7 +260,7 @@ def test_raster_finishing_sphere(freeform_stl):
     from nodes.three_d_milling import generate_raster_finishing
 
     req = ThreeDFinishingRequest(
-        mesh_file_path=str(freeform_stl),
+        file_id="test", mesh_file_path=str(freeform_stl),
         stepover=0.3,
         scan_angle=0.0,
     )
@@ -277,7 +279,7 @@ def test_raster_finishing_z_follows_surface(freeform_stl):
     from nodes.three_d_milling import generate_raster_finishing
 
     req = ThreeDFinishingRequest(
-        mesh_file_path=str(freeform_stl),
+        file_id="test", mesh_file_path=str(freeform_stl),
         stepover=0.5,
         scan_angle=0.0,
     )
@@ -297,12 +299,12 @@ def test_raster_finishing_scan_angle(freeform_stl):
     from nodes.three_d_milling import generate_raster_finishing
 
     req_0 = ThreeDFinishingRequest(
-        mesh_file_path=str(freeform_stl),
+        file_id="test", mesh_file_path=str(freeform_stl),
         stepover=0.5,
         scan_angle=0.0,
     )
     req_90 = ThreeDFinishingRequest(
-        mesh_file_path=str(freeform_stl),
+        file_id="test", mesh_file_path=str(freeform_stl),
         stepover=0.5,
         scan_angle=90.0,
     )
@@ -327,7 +329,7 @@ def test_raster_finishing_invalid_file():
     """Non-existent file should raise."""
     from nodes.three_d_milling import generate_raster_finishing
 
-    req = ThreeDFinishingRequest(mesh_file_path="/tmp/nonexistent_xyz.stl")
+    req = ThreeDFinishingRequest(file_id="test", mesh_file_path="/tmp/nonexistent_xyz.stl")
     with pytest.raises(FileNotFoundError):
         generate_raster_finishing(req)
 
@@ -345,7 +347,7 @@ def test_roughing_finishing_merged_sbp(freeform_stl):
 
     # Generate roughing
     roughing_req = ThreeDRoughingRequest(
-        mesh_file_path=str(freeform_stl),
+        file_id="test", mesh_file_path=str(freeform_stl),
         z_step=10.0,
         stock_to_leave=0.5,
     )
@@ -354,7 +356,7 @@ def test_roughing_finishing_merged_sbp(freeform_stl):
 
     # Generate finishing
     finishing_req = ThreeDFinishingRequest(
-        mesh_file_path=str(freeform_stl),
+        file_id="test", mesh_file_path=str(freeform_stl),
         stepover=0.5,
         scan_angle=0.0,
     )

--- a/backend/tests/test_api_3d_finishing.py
+++ b/backend/tests/test_api_3d_finishing.py
@@ -10,23 +10,19 @@ def client():
     return TestClient(app)
 
 
-def test_3d_finishing_endpoint(client, freeform_stl):
-    """Upload STL then generate finishing toolpath."""
-    with open(freeform_stl, "rb") as f:
+def test_3d_finishing_endpoint(client, simple_box_step):
+    """Upload STEP then generate finishing toolpath."""
+    with open(simple_box_step, "rb") as f:
         upload_resp = client.post(
-            "/api/upload-mesh",
-            files={"file": ("sphere.stl", f, "application/octet-stream")},
+            "/api/upload-step",
+            files={"file": ("box.step", f, "application/octet-stream")},
         )
     assert upload_resp.status_code == 200
-    mesh_path = upload_resp.json()["mesh_file_path"]
+    file_id = upload_resp.json()["file_id"]
 
     resp = client.post(
         "/api/3d-finishing",
-        json={
-            "mesh_file_path": mesh_path,
-            "stepover": 0.3,
-            "scan_angle": 0.0,
-        },
+        json={"file_id": file_id, "stepover": 0.3, "scan_angle": 0.0},
     )
     assert resp.status_code == 200
     data = resp.json()
@@ -37,9 +33,9 @@ def test_3d_finishing_endpoint(client, freeform_stl):
 
 
 def test_3d_finishing_invalid_file(client):
-    """Non-existent mesh file should return 400."""
+    """Non-existent file_id should return 404."""
     resp = client.post(
         "/api/3d-finishing",
-        json={"mesh_file_path": "/tmp/nonexistent_xyz.stl"},
+        json={"file_id": "nonexistent_xyz"},
     )
-    assert resp.status_code == 400
+    assert resp.status_code == 404

--- a/backend/tests/test_api_3d_milling.py
+++ b/backend/tests/test_api_3d_milling.py
@@ -1,7 +1,5 @@
 """API tests for 3D roughing endpoint."""
 
-import io
-
 import pytest
 from fastapi.testclient import TestClient
 from main import app
@@ -12,32 +10,25 @@ def client():
     return TestClient(app)
 
 
-def test_3d_roughing_endpoint(client, freeform_stl):
-    """Upload STL then call 3D roughing endpoint."""
-    # First upload the mesh
-    with open(freeform_stl, "rb") as f:
+def test_3d_roughing_endpoint(client, simple_box_step):
+    """Upload STEP then call 3D roughing endpoint with file_id."""
+    with open(simple_box_step, "rb") as f:
         upload_resp = client.post(
-            "/api/upload-mesh",
-            files={"file": ("sphere.stl", f, "application/octet-stream")},
+            "/api/upload-step",
+            files={"file": ("box.step", f, "application/octet-stream")},
         )
     assert upload_resp.status_code == 200
-    mesh_file_path = upload_resp.json()["mesh_file_path"]
+    file_id = upload_resp.json()["file_id"]
 
-    # Call roughing endpoint
     resp = client.post(
         "/api/3d-roughing",
-        json={
-            "mesh_file_path": mesh_file_path,
-            "z_step": 5.0,
-            "stock_to_leave": 0.0,
-        },
+        json={"file_id": file_id, "z_step": 5.0, "stock_to_leave": 0.0},
     )
     assert resp.status_code == 200
     data = resp.json()
     assert "toolpaths" in data
     assert len(data["toolpaths"]) > 0
 
-    # Verify toolpath structure
     tp = data["toolpaths"][0]
     assert tp["operation_id"].startswith("3d_roughing_")
     assert tp["contour_type"] == "exterior"
@@ -45,13 +36,9 @@ def test_3d_roughing_endpoint(client, freeform_stl):
 
 
 def test_3d_roughing_invalid_file(client):
-    """Should return 400 for non-existent mesh file."""
+    """Should return 404 for non-existent file_id."""
     resp = client.post(
         "/api/3d-roughing",
-        json={
-            "mesh_file_path": "/tmp/does_not_exist_xyz.stl",
-            "z_step": 5.0,
-        },
+        json={"file_id": "nonexistent_xyz", "z_step": 5.0},
     )
-    assert resp.status_code == 400
-    assert "not found" in resp.json()["detail"].lower() or "exist" in resp.json()["detail"].lower()
+    assert resp.status_code == 404

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -271,7 +271,7 @@ export async function generateSbpZip(
 /** 3D Milling API */
 
 export async function generate3dRoughing(
-  meshFilePath: string,
+  fileId: string,
   zStep: number = 3.0,
   stockToLeave: number = 0.5,
   tool?: { diameter: number; type: string; flutes: number },
@@ -279,7 +279,7 @@ export async function generate3dRoughing(
   spindleSpeed?: number,
 ): Promise<ThreeDRoughingResult> {
   const body: Record<string, unknown> = {
-    mesh_file_path: meshFilePath,
+    file_id: fileId,
     z_step: zStep,
     stock_to_leave: stockToLeave,
   };
@@ -294,7 +294,7 @@ export async function generate3dRoughing(
 }
 
 export async function generate3dFinishing(
-  meshFilePath: string,
+  fileId: string,
   stepover: number = 0.15,
   scanAngle: number = 0.0,
   tool?: { diameter: number; type: string; flutes: number },
@@ -302,7 +302,7 @@ export async function generate3dFinishing(
   spindleSpeed?: number,
 ): Promise<ThreeDFinishingResult> {
   const body: Record<string, unknown> = {
-    mesh_file_path: meshFilePath,
+    file_id: fileId,
     stepover,
     scan_angle: scanAngle,
   };

--- a/frontend/src/nodes/OperationNode.tsx
+++ b/frontend/src/nodes/OperationNode.tsx
@@ -77,12 +77,12 @@ export default function OperationNode({ id, selected }: NodeProps) {
       setNodes((nds) =>
         nds.map((n) =>
           n.id === id
-            ? { ...n, data: { ...n.data, detectedOperations: det, assignments: assign, sheetSettings: sheet, placements: plc, objectOrigins, boundingBoxes, outlines, activeSheetId: sid } }
+            ? { ...n, data: { ...n.data, detectedOperations: det, assignments: assign, sheetSettings: sheet, placements: plc, objectOrigins, boundingBoxes, outlines, activeSheetId: sid, fileId: upstream?.fileId } }
             : n
         )
       );
     },
-    [id, setNodes, upstream?.activeSheetId]
+    [id, setNodes, upstream?.activeSheetId, upstream?.fileId]
   );
 
   // Auto-detect operations when upstream data changes

--- a/frontend/src/nodes/ThreeDMillingNode.tsx
+++ b/frontend/src/nodes/ThreeDMillingNode.tsx
@@ -2,7 +2,6 @@ import { useCallback, useState } from "react";
 import { type NodeProps, useReactFlow } from "@xyflow/react";
 import { generate3dRoughing, generate3dFinishing } from "../api";
 import type {
-  MeshImportResult,
   OperationAssignment,
   ThreeDRoughingResult,
   ThreeDFinishingResult,
@@ -26,16 +25,14 @@ export default function ThreeDMillingNode({ id, selected }: NodeProps) {
 
   const { setNodes } = useReactFlow();
 
-  // Read upstream MeshImportNode data
-  const extractMesh = useCallback(
-    (d: Record<string, unknown>): MeshImportResult | undefined => {
-      const br = d.brepResult as MeshImportResult | undefined;
-      if (br && br.mesh_file_path) return br;
-      return undefined;
+  // Read upstream fileId from OperationNode
+  const extractFileId = useCallback(
+    (d: Record<string, unknown>): string | undefined => {
+      return d.fileId as string | undefined;
     },
     [],
   );
-  const meshData = useUpstreamData(id, `${id}-mesh`, extractMesh);
+  const fileId = useUpstreamData(id, `${id}-operations`, extractFileId);
 
   // Read upstream OperationNode — find enabled 3d_roughing assignment
   const extractRoughing = useCallback(
@@ -72,13 +69,13 @@ export default function ThreeDMillingNode({ id, selected }: NodeProps) {
   );
 
   const handleGenerateRoughing = useCallback(async () => {
-    if (!meshData?.mesh_file_path) return;
+    if (!fileId) return;
     setRoughingStatus("loading");
     setRoughingError("");
     try {
       const s = roughingAssignment?.settings;
       const res = await generate3dRoughing(
-        meshData.mesh_file_path,
+        fileId,
         s?.z_step ?? 3.0,
         s?.stock_to_leave ?? 0.5,
         s
@@ -104,16 +101,16 @@ export default function ThreeDMillingNode({ id, selected }: NodeProps) {
       setRoughingError(e instanceof Error ? e.message : "Generation failed");
       setRoughingStatus("error");
     }
-  }, [meshData, roughingAssignment, id, setNodes]);
+  }, [fileId, roughingAssignment, id, setNodes]);
 
   const handleGenerateFinishing = useCallback(async () => {
-    if (!meshData?.mesh_file_path) return;
+    if (!fileId) return;
     setFinishingStatus("loading");
     setFinishingError("");
     try {
       const s = finishingAssignment?.settings;
       const res = await generate3dFinishing(
-        meshData.mesh_file_path,
+        fileId,
         s?.stepover_3d ?? 0.15,
         s?.scan_angle ?? 0.0,
         s
@@ -141,7 +138,7 @@ export default function ThreeDMillingNode({ id, selected }: NodeProps) {
       );
       setFinishingStatus("error");
     }
-  }, [meshData, finishingAssignment, id, setNodes]);
+  }, [fileId, finishingAssignment, id, setNodes]);
 
   // Count Z levels and total passes from roughing result
   const roughingZLevels = roughingResult
@@ -168,37 +165,18 @@ export default function ThreeDMillingNode({ id, selected }: NodeProps) {
     <NodeShell category="cam" selected={selected}>
       <LabeledHandle
         type="target"
-        id={`${id}-mesh`}
-        label="mesh"
-        dataType="geometry"
-        index={0}
-        total={2}
-      />
-      <LabeledHandle
-        type="target"
         id={`${id}-operations`}
         label="operations"
         dataType="geometry"
-        index={1}
-        total={2}
       />
 
       <div style={headerStyle}>3D Milling</div>
 
-      {!meshData && roughingStatus !== "loading" && (
+      {!roughingAssignment && !finishingAssignment && roughingStatus !== "loading" && (
         <div style={{ color: "var(--text-muted)", fontSize: 11 }}>
-          Connect Mesh Import
+          Connect Operation node
         </div>
       )}
-
-      {!roughingAssignment &&
-        !finishingAssignment &&
-        meshData &&
-        roughingStatus !== "loading" && (
-          <div style={{ color: "var(--text-muted)", fontSize: 11 }}>
-            Connect Operation node
-          </div>
-        )}
 
       {/* --- Roughing Section --- */}
       {roughingAssignment && (
@@ -209,13 +187,13 @@ export default function ThreeDMillingNode({ id, selected }: NodeProps) {
           )}
           <button
             onClick={handleGenerateRoughing}
-            disabled={!meshData || roughingStatus === "loading"}
+            disabled={!fileId || roughingStatus === "loading"}
             style={{
               ...buttonStyle,
               opacity:
-                !meshData || roughingStatus === "loading" ? 0.5 : 1,
+                !fileId || roughingStatus === "loading" ? 0.5 : 1,
               cursor:
-                !meshData || roughingStatus === "loading"
+                !fileId || roughingStatus === "loading"
                   ? "not-allowed"
                   : "pointer",
             }}
@@ -253,14 +231,14 @@ export default function ThreeDMillingNode({ id, selected }: NodeProps) {
           )}
           <button
             onClick={handleGenerateFinishing}
-            disabled={!meshData || finishingStatus === "loading"}
+            disabled={!fileId || finishingStatus === "loading"}
             style={{
               ...buttonStyle,
               background: "var(--color-toolpath, #6366f1)",
               opacity:
-                !meshData || finishingStatus === "loading" ? 0.5 : 1,
+                !fileId || finishingStatus === "loading" ? 0.5 : 1,
               cursor:
-                !meshData || finishingStatus === "loading"
+                !fileId || finishingStatus === "loading"
                   ? "not-allowed"
                   : "pointer",
             }}
@@ -284,15 +262,15 @@ export default function ThreeDMillingNode({ id, selected }: NodeProps) {
       )}
 
       {/* --- No operation assigned: show default generate button --- */}
-      {!roughingAssignment && !finishingAssignment && meshData && (
+      {!roughingAssignment && !finishingAssignment && fileId && (
         <button
           onClick={handleGenerateRoughing}
-          disabled={!meshData || roughingStatus === "loading"}
+          disabled={!fileId || roughingStatus === "loading"}
           style={{
             ...buttonStyle,
-            opacity: !meshData || roughingStatus === "loading" ? 0.5 : 1,
+            opacity: !fileId || roughingStatus === "loading" ? 0.5 : 1,
             cursor:
-              !meshData || roughingStatus === "loading"
+              !fileId || roughingStatus === "loading"
                 ? "not-allowed"
                 : "pointer",
           }}


### PR DESCRIPTION
## Summary
- 3D Milling ノードの mesh 入力ピンを廃止し、operations の1入力のみに簡素化
- roughing/finishing API を `mesh_file_path` → `file_id` に変更、バックエンドで STEP→STL 自動変換（キャッシュ付き）
- OperationNode が `fileId` を下流に伝搬するよう修正

## Test plan
- [x] バックエンド全テスト通過（263 passed, 2 skipped）
- [x] TypeScript 型チェック通過
- [x] 3D Milling ノードが Operation ノードから file_id を正しく受け取り、roughing/finishing 生成可能なことを確認
- [ ] `make dev` で実際のフローを動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)